### PR TITLE
Support compact payload format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/.settings
 **/.classpath
 **/.DS_Store
+bin/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example usage:
     BayeuxParameters params = login("foo@bar.com", "password");
     
     // The event consumer
-    Consumer<Map<String, Object>> consumer = event -> System.out.println(String.format("Received:\n%s", event));
+    Consumer<EmpEvent<?>> consumer = event -> System.out.println(String.format("Received:\n%s", event.getPayload()));
     
     // The EMP connector
     EmpConnector connector = new EmpConnector(params);

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
             <organization>Salesforce.com, Inc.</organization>
             <organizationUrl>http://www.salesforce.com</organizationUrl>
         </developer>
+        <developer>
+            <name>Lawrence McAlpin</name>
+            <email>lmcalpin@salesforce.com</email>
+            <organization>Salesforce.com, Inc.</organization>
+            <organizationUrl>http://www.salesforce.com</organizationUrl>
+        </developer>
     </developers>
 
     <scm>
@@ -65,6 +71,11 @@
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+	        <version>1.7.7</version>
+        </dependency>
         <dependency>
             <groupId>org.cometd.java</groupId>
             <artifactId>cometd-java-client</artifactId>

--- a/src/main/java/com/salesforce/emp/connector/BayeuxParameters.java
+++ b/src/main/java/com/salesforce/emp/connector/BayeuxParameters.java
@@ -6,7 +6,10 @@ package com.salesforce.emp.connector;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.util.ssl.SslContextFactory;

--- a/src/main/java/com/salesforce/emp/connector/ClientExtension.java
+++ b/src/main/java/com/salesforce/emp/connector/ClientExtension.java
@@ -1,0 +1,72 @@
+/* 
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license. 
+ * For full license text, see LICENSE.TXT file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.emp.connector;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.cometd.bayeux.Channel;
+import org.cometd.bayeux.Message;
+import org.cometd.bayeux.client.ClientSession;
+import org.cometd.bayeux.client.ClientSession.Extension.Adapter;
+
+/**
+ * The Bayeux extension for replay
+ *
+ * @author hal.hildebrand
+ * @since 202
+ */
+public abstract class ClientExtension<T> extends Adapter {
+    private final ConcurrentMap<String, T> dataMap;
+    private final AtomicBoolean supported = new AtomicBoolean();
+
+    public ClientExtension(ConcurrentMap<String, T> dataMap) {
+        this.dataMap = dataMap;
+    }
+    
+    public abstract String getExtensionName();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean rcv(ClientSession session, Message.Mutable message) {
+        T data = (T)message.get(getExtensionName());
+        if (this.supported.get() && data != null) {
+            try {
+                dataMap.put(message.getChannel(), data);
+            } catch (ClassCastException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean rcvMeta(ClientSession session, Message.Mutable message) {
+        switch (message.getChannel()) {
+        case Channel.META_HANDSHAKE:
+            Map<String, Object> ext = message.getExt(false);
+            this.supported.set(ext != null && Boolean.TRUE.equals(ext.get(getExtensionName())));
+        }
+        return true;
+    }
+
+    @Override
+    public boolean sendMeta(ClientSession session, Message.Mutable message) {
+        switch (message.getChannel()) {
+        case Channel.META_HANDSHAKE:
+            message.getExt(true).put(getExtensionName(), Boolean.TRUE);
+            break;
+        case Channel.META_SUBSCRIBE:
+            if (supported.get()) {
+                message.getExt(true).put(getExtensionName(), dataMap);
+            }
+            break;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/salesforce/emp/connector/EmpEvent.java
+++ b/src/main/java/com/salesforce/emp/connector/EmpEvent.java
@@ -1,0 +1,36 @@
+package com.salesforce.emp.connector;
+
+import java.util.Map;
+
+/**
+ * A Platform Event that was published in Salesforce.
+ * 
+ * @author lmcalpin
+ * @since 212
+ */
+public class EmpEvent<T> {
+    private final long replayId;
+    private final String schemaId;
+    private final PayloadFormat payloadFormat;
+    private final T payload;
+    
+    public EmpEvent(long replayId, String schemaId, PayloadFormat payloadFormat, T payload) {
+        this.replayId = replayId;
+        this.schemaId = schemaId;
+        this.payloadFormat = payloadFormat;
+        this.payload = payload;
+    }
+    
+    public long getReplayId() {
+        return replayId;
+    }
+    public String getSchemaId() {
+        return schemaId;
+    }
+    public PayloadFormat getPayloadFormat() {
+        return payloadFormat;
+    }
+    public T getPayload() {
+        return payload;
+    }
+}

--- a/src/main/java/com/salesforce/emp/connector/FormatExtension.java
+++ b/src/main/java/com/salesforce/emp/connector/FormatExtension.java
@@ -9,15 +9,15 @@ package com.salesforce.emp.connector;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * The Bayeux extension for replay
+ * The Bayeux extension for payload formats
  *
- * @author hal.hildebrand
- * @since 202
+ * @author lmcalpin
+ * @since 212
  */
-public class ReplayExtension extends ClientExtension<Long> {
-    private static final String EXTENSION_NAME = "replay";
+public class FormatExtension extends ClientExtension<String> {
+    private static final String EXTENSION_NAME = "payload.format";
 
-    public ReplayExtension(ConcurrentMap<String, Long> dataMap) {
+    public FormatExtension(ConcurrentMap<String, String> dataMap) {
         super(dataMap);
     }
 

--- a/src/main/java/com/salesforce/emp/connector/LoginHelper.java
+++ b/src/main/java/com/salesforce/emp/connector/LoginHelper.java
@@ -79,7 +79,7 @@ public class LoginHelper {
 
     public static final String COMETD_REPLAY = "/cometd/";
     public static final String COMETD_REPLAY_OLD = "/cometd/replay/";
-    static final String LOGIN_ENDPOINT = "https://login.salesforce.com";
+    static final String LOGIN_ENDPOINT = "http://lmcalpin-wsl5.internal.salesforce.com:6109";
     private static final String ENV_END = "</soapenv:Body></soapenv:Envelope>";
     private static final String ENV_START = "<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' "
             + "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "

--- a/src/main/java/com/salesforce/emp/connector/LoginHelper.java
+++ b/src/main/java/com/salesforce/emp/connector/LoginHelper.java
@@ -79,7 +79,7 @@ public class LoginHelper {
 
     public static final String COMETD_REPLAY = "/cometd/";
     public static final String COMETD_REPLAY_OLD = "/cometd/replay/";
-    static final String LOGIN_ENDPOINT = "http://lmcalpin-wsl5.internal.salesforce.com:6109";
+    static final String LOGIN_ENDPOINT = "http://login.salesforce.com";
     private static final String ENV_END = "</soapenv:Body></soapenv:Envelope>";
     private static final String ENV_START = "<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' "
             + "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "

--- a/src/main/java/com/salesforce/emp/connector/PayloadFormat.java
+++ b/src/main/java/com/salesforce/emp/connector/PayloadFormat.java
@@ -1,0 +1,42 @@
+package com.salesforce.emp.connector;
+
+import java.util.Base64;
+import java.util.Map;
+
+import org.cometd.bayeux.Message;
+
+/**
+ * An enumeration of the various supported formats for received events.
+ * <br>
+ * EXPANDED - receive events expanded into JSON consistent with the Streaming API
+ * <br>
+ * COMPACT - receive events in a compact Avro serialized format
+ * 
+ * @author lmcalpin
+ */
+public enum PayloadFormat {
+    EXPANDED, COMPACT;
+    
+    private static final Base64.Decoder base64Decoder = Base64.getDecoder();
+    
+    public EmpEvent<?> toEvent(Message message) {
+        if (this == EXPANDED) {
+            Map<String, Object> messageData = message.getDataAsMap();
+            String schemaId = (String)messageData.get("schema");
+            Map<String, Object> eventMetadata = (Map<String, Object>)messageData.get("event");
+            Long replayId = (Long)eventMetadata.get("replayId");
+            Map<String, Object> payload = (Map<String, Object>)messageData.get("payload");
+            return new EmpEvent<Map<String,Object>>(replayId, schemaId, this, payload);
+        } else if (this == COMPACT) {
+            Object[] dataList = (Object[])message.getData();
+            assert dataList.length == 3;
+            @SuppressWarnings("unused")
+            String organizationId = (String)dataList[0];
+            String schemaId = (String)dataList[1];
+            String payloadStr = (String)dataList[2];
+            byte[] payload = base64Decoder.decode(payloadStr);
+            return new EmpEvent<byte[]>(Long.valueOf(message.getId()), schemaId, this, payload);
+        }
+        throw new IllegalStateException();
+    }
+}

--- a/src/main/java/com/salesforce/emp/connector/example/BearerTokenExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/BearerTokenExample.java
@@ -6,12 +6,12 @@ package com.salesforce.emp.connector.example;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.salesforce.emp.connector.BayeuxParameters;
 import com.salesforce.emp.connector.EmpConnector;
+import com.salesforce.emp.connector.EmpEvent;
 import com.salesforce.emp.connector.TopicSubscription;
 
 /**
@@ -48,7 +48,7 @@ public class BearerTokenExample {
             }
         };
 
-        Consumer<Map<String, Object>> consumer = event -> System.out.println(String.format("Received:\n%s", event));
+        Consumer<EmpEvent<?>> consumer = event -> System.out.println(String.format("Received:%d\n%s", event.getReplayId(), event.getPayload()));
         EmpConnector connector = new EmpConnector(params);
 
         connector.start().get(5, TimeUnit.SECONDS);

--- a/src/main/java/com/salesforce/emp/connector/example/CompactFormatExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/CompactFormatExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016, salesforce.com, inc. All rights reserved. Licensed under the BSD 3-Clause license. For full
+ * license text, see LICENSE.TXT file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.emp.connector.example;
+
+import static com.salesforce.emp.connector.LoginHelper.login;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+
+import com.salesforce.emp.connector.BayeuxParameters;
+import com.salesforce.emp.connector.EmpConnector;
+import com.salesforce.emp.connector.EmpEvent;
+import com.salesforce.emp.connector.PayloadFormat;
+import com.salesforce.emp.connector.TopicSubscription;
+import com.salesforce.emp.connector.schema.PlatformEventSchemaRepository;
+
+/**
+ * An example of using the EMP connector using login credentials, retrieving compact formatted Platform Events.  The Bayeux messages that 
+ * we receive will contain B64-encoded bytes for event data encoded in Avro.
+ *
+ * @author lmcalpin
+ * @since 212
+ */
+public class CompactFormatExample {
+    public static void main(String[] argv) throws Exception {
+        if (argv.length < 3 || argv.length > 4) {
+            System.err.println("Usage: LoginExample username password topic [replayFrom]");
+            System.exit(1);
+        }
+        long replayFrom = EmpConnector.REPLAY_FROM_EARLIEST;
+        if (argv.length == 4) {
+            replayFrom = Long.parseLong(argv[3]);
+        }
+
+        BayeuxParameters params;
+        try {
+            params = login(argv[0], argv[1]);
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+            System.exit(1);
+            throw e;
+        }
+
+        Map<String, Schema> schemas = new HashMap<>();
+        PlatformEventSchemaRepository schemaRepository = new PlatformEventSchemaRepository(params);
+        Consumer<EmpEvent<?>> consumer = event -> {
+            byte[] payload = (byte[])event.getPayload();
+            Schema schema = schemas.computeIfAbsent(event.getSchemaId(), s -> schemaRepository.getSchema(s));
+            try {
+                BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(payload), null);
+                final GenericDatumReader<Object> reader = new GenericDatumReader<>(schema);
+                GenericRecord deserializedPayload = (GenericRecord)reader.read(null, decoder);
+                System.out.println(String.format("Received:%d\n%s", event.getReplayId(), deserializedPayload));
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        };
+        EmpConnector connector = new EmpConnector(params);
+
+        connector.start().get(5, TimeUnit.SECONDS);
+
+        TopicSubscription subscription = connector.subscribe(argv[2], replayFrom, PayloadFormat.COMPACT, consumer)
+                                                  .get(5, TimeUnit.SECONDS);
+
+        System.out.println(String.format("Subscribed: %s", subscription));
+    }
+}

--- a/src/main/java/com/salesforce/emp/connector/example/DevLoginExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/DevLoginExample.java
@@ -9,12 +9,14 @@ package com.salesforce.emp.connector.example;
 import static com.salesforce.emp.connector.LoginHelper.login;
 
 import java.net.URL;
-import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import com.salesforce.emp.connector.BayeuxParameters;
 import com.salesforce.emp.connector.EmpConnector;
+import com.salesforce.emp.connector.EmpEvent;
 import com.salesforce.emp.connector.TopicSubscription;
 
 /**
@@ -29,7 +31,7 @@ public class DevLoginExample {
             System.err.println("Usage: DevLoginExample url username password topic [replayFrom]");
             System.exit(1);
         }
-        Consumer<Map<String, Object>> consumer = event -> System.out.println(String.format("Received:\n%s", event));
+        Consumer<EmpEvent<?>> consumer = event -> System.out.println(String.format("Received:%d\n%s", event.getReplayId(), event.getPayload()));
         BayeuxParameters params = login(new URL(argv[0]), argv[1], argv[2]);
         EmpConnector connector = new EmpConnector(params);
 

--- a/src/main/java/com/salesforce/emp/connector/example/LoginExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/LoginExample.java
@@ -8,12 +8,13 @@ package com.salesforce.emp.connector.example;
 
 import static com.salesforce.emp.connector.LoginHelper.login;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.salesforce.emp.connector.BayeuxParameters;
 import com.salesforce.emp.connector.EmpConnector;
+import com.salesforce.emp.connector.EmpEvent;
+import com.salesforce.emp.connector.PayloadFormat;
 import com.salesforce.emp.connector.TopicSubscription;
 
 /**
@@ -42,12 +43,12 @@ public class LoginExample {
             throw e;
         } 
 
-        Consumer<Map<String, Object>> consumer = event -> System.out.println(String.format("Received:\n%s", event));
+        Consumer<EmpEvent<?>> consumer = event -> System.out.println(String.format("Received:%d\n%s", event.getReplayId(), event.getPayload()));
         EmpConnector connector = new EmpConnector(params);
 
         connector.start().get(5, TimeUnit.SECONDS);
 
-        TopicSubscription subscription = connector.subscribe(argv[2], replayFrom, consumer).get(5, TimeUnit.SECONDS);
+        TopicSubscription subscription = connector.subscribe(argv[2], replayFrom, PayloadFormat.EXPANDED, consumer).get(5, TimeUnit.SECONDS);
 
         System.out.println(String.format("Subscribed: %s", subscription));
     }

--- a/src/main/java/com/salesforce/emp/connector/schema/PlatformEventSchemaRepository.java
+++ b/src/main/java/com/salesforce/emp/connector/schema/PlatformEventSchemaRepository.java
@@ -1,0 +1,35 @@
+package com.salesforce.emp.connector.schema;
+
+import org.apache.avro.Schema;
+
+import com.salesforce.emp.connector.BayeuxParameters;
+import com.salesforce.emp.util.RestUtil;
+
+/**
+ * Retrieves Avro schema that have been registered in the Platform Event schema repository. 
+ * 
+ * @author lmcalpin
+ * @since 212
+ */
+public class PlatformEventSchemaRepository {
+    private final BayeuxParameters bayeuxParams;
+    private final RestUtil restUtil;
+    
+    public PlatformEventSchemaRepository(BayeuxParameters bayeuxParams) {
+        this.bayeuxParams = bayeuxParams;
+        this.restUtil = new RestUtil(bayeuxParams);
+    }
+
+    public Schema getSchema(String schemaId) {
+        Schema.Parser parser = new Schema.Parser();
+        return parser.parse(getSchemaAsString(schemaId));
+    }
+    
+    public String getSchemaAsString(String schemaId) {
+        try {
+            return restUtil.get(bayeuxParams.host().toExternalForm() + "/services/data/v41.0/event/eventSchema/" + schemaId);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/com/salesforce/emp/util/RestUtil.java
+++ b/src/main/java/com/salesforce/emp/util/RestUtil.java
@@ -1,0 +1,38 @@
+package com.salesforce.emp.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.text.ParseException;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpResponse;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+
+import com.salesforce.emp.connector.BayeuxParameters;
+
+/**
+ * Utility class to call REST resources on the Salesforce platform.
+ * 
+ * @author lmcalpin
+ * @since 212
+ */
+public class RestUtil {
+    private final BayeuxParameters parameters;
+    
+    public RestUtil(BayeuxParameters bayeuxParameters) {
+        this.parameters = bayeuxParameters;
+    }
+    
+    public String get(String serviceUrl) throws Exception {
+        HttpClient client = new HttpClient(parameters.sslContextFactory());
+        client.getProxyConfiguration().getProxies().addAll(parameters.proxies());
+        client.start();
+
+        // schema retrieval requests must be GETs
+        Request get = client.newRequest(serviceUrl);
+        get.header("Authorization", "Bearer " + parameters.bearerToken());
+        ContentResponse response = get.send();
+        return response.getContentAsString();
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration debug="true"> 
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"> 
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Adds support for the ability to specify EXPANDED vs COMPACT payload formats.
Added an example demonstrating deserializing the COMPACT payload formatted messages using Avro.
Existing APIs were altered because payload formats now differ between the two formats and we can't always count on consuming a Map.