### PR TITLE
Adds bearer token provider hook for reauth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.cometd.java</groupId>
             <artifactId>cometd-java-client</artifactId>
-            <version>3.0.9</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
FYI @knhage 

- Added the hook (setBearerTokenProvider method) to accept a bearer token provider to be called whenever a 401 error is received from the server.
- Changed cometd version to 3.1.0.
- Modified LoginExample class to show an example bearer token provider function. 