### PR TITLE
Encapsulate username and password inside a CDATA

### DIFF
--- a/src/main/java/com/salesforce/emp/connector/LoginHelper.java
+++ b/src/main/java/com/salesforce/emp/connector/LoginHelper.java
@@ -163,7 +163,7 @@ public class LoginHelper {
     }
 
     private static byte[] soapXmlForLogin(String username, String password) throws UnsupportedEncodingException {
-        return (ENV_START + "  <urn:login>" + "    <urn:username>" + username + "</urn:username>" + "    <urn:password>"
-                + password + "</urn:password>" + "  </urn:login>" + ENV_END).getBytes("UTF-8");
+        return (ENV_START + "  <urn:login><![CDATA[" + "    <urn:username>" + username + "</urn:username>" + "    <urn:password>"
+                + password + "</urn:password>" + "]]></urn:login>" + ENV_END).getBytes("UTF-8");
     }
 }


### PR DESCRIPTION
I have a password that start with &, So that the password field isn't in a CDATA, the soap was breaking. I prefer to encapsulate username and password inside a CDATA to avoid the SOAP breaking due to a special Character