### PR TITLE
Change default replay ID to -1 in EMP Connector if not specified 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run EMP Connector using an OAuth access token, use this command.
 
 `$ java -classpath target/emp-connector-0.0.1-SNAPSHOT-phat.jar com.salesforce.emp.connector.example.BearerTokenExample <instance_URL> <token> <channel> [optional_replay_id]`
 
-The last parameter is the replay ID, which is the position in the stream from which you want to receive event messages. This parameter is optional. If not specified, EMP Connector fetches events starting from the earliest retained event message (-2 option). For more information, see [Message Durability](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm).
+The last parameter is the replay ID, which is the position in the stream from which you want to receive event messages. This parameter is optional. If not specified, EMP Connector fetches events starting from the tip, the newly received event messages (-1 option). For more information, see [Message Durability](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm).
 
 ## Subscription Filtering for PushTopic Channels
 If you subscribe to a PushTopic channel with a filter, enclose the entire channel and filter information within quotes on the command line. Do not use single quotes around field values. Otherwise, EMP Connector doesn't work properly. For example, this command line uses filters on the TestAccount PushTopic.

--- a/src/main/java/com/salesforce/emp/connector/EmpConnector.java
+++ b/src/main/java/com/salesforce/emp/connector/EmpConnector.java
@@ -65,7 +65,7 @@ public class EmpConnector {
          */
         @Override
         public long getReplayFrom() {
-            return replay.getOrDefault(topicWithoutQueryString(topic), REPLAY_FROM_EARLIEST);
+            return replay.getOrDefault(topicWithoutQueryString(topic), REPLAY_FROM_TIP);
         }
 
         /*

--- a/src/main/java/com/salesforce/emp/connector/example/BearerTokenExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/BearerTokenExample.java
@@ -34,7 +34,7 @@ public class BearerTokenExample {
             System.err.println("Usage: BearerTokenExample url token topic [replayFrom]");
             System.exit(1);
         }
-        long replayFrom = EmpConnector.REPLAY_FROM_EARLIEST;
+        long replayFrom = EmpConnector.REPLAY_FROM_TIP;
         if (argv.length == 4) {
             replayFrom = Long.parseLong(argv[3]);
         }

--- a/src/main/java/com/salesforce/emp/connector/example/DevLoginExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/DevLoginExample.java
@@ -66,7 +66,7 @@ public class DevLoginExample {
 
         connector.start().get(5, TimeUnit.SECONDS);
 
-        long replayFrom = EmpConnector.REPLAY_FROM_EARLIEST;
+        long replayFrom = EmpConnector.REPLAY_FROM_TIP;
         if (argv.length == 5) {
             replayFrom = Long.parseLong(argv[4]);
         }

--- a/src/main/java/com/salesforce/emp/connector/example/LoginExample.java
+++ b/src/main/java/com/salesforce/emp/connector/example/LoginExample.java
@@ -38,7 +38,7 @@ public class LoginExample {
             System.err.println("Usage: LoginExample username password topic [replayFrom]");
             System.exit(1);
         }
-        long replayFrom = EmpConnector.REPLAY_FROM_EARLIEST;
+        long replayFrom = EmpConnector.REPLAY_FROM_TIP;
         if (argv.length == 4) {
             replayFrom = Long.parseLong(argv[3]);
         }
@@ -55,7 +55,7 @@ public class LoginExample {
 
         BayeuxParameters params = tokenProvider.login();
 
-        Consumer<Map<String, Object>> consumer = event -> workerThreadPool.submit(() -> System.out.println(String.format("Received:\n%s, \nEvent processed by threadName:%s, threadId: %s", JSON.toString(event), Thread.currentThread().getName(), Thread.currentThread().getId())));
+        Consumer<Map<String, Object>> consumer = event -> workerThreadPool.submit(() -> System.out.println(String.format("Received:\n%s", JSON.toString(event))));
 
         EmpConnector connector = new EmpConnector(params);
 


### PR DESCRIPTION
Description of changes:
- Replay ID default was -2 (fetch earliest events). Change to -1 (get only new events) to match the default in Salesforce.
- LoginExample doesn't print out debug log messages, so removed the logging for thread info.
- Update Readme.md to reflect the new Replay ID default.